### PR TITLE
Sets the editor to prefer dark mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 __pycache__
+test.map
+test.png
+# Unnecessary Krita files. May change over time
+assets/.eraser.kra-autosave.kra
+assets/eraser.kra~
+assets/eraser.png~
+assets/eye-dropper.kra~
+assets/pencil.kra~
+assets/pencil.png~

--- a/main.py
+++ b/main.py
@@ -13,6 +13,8 @@ class MyWindow(gtk.Window):
     gtk.Window.__init__(self)
     self.connect("destroy", gtk.main_quit)
     self.set_default_size(300, 250)
+    settings = gtk.Settings.get_default()
+    settings.set_property("gtk-application-prefer-dark-theme", True)
 
     header = gtk.HeaderBar(title="Tile Editor")
     header.props.show_close_button = True


### PR DESCRIPTION
The editor will now prefer dark mode over light mode, so the icons won't be invisible. @macmv should consider making inverted icons for those who want to use a light theme. If we decide to go that route we should add a dropdown so Windows users can change themes.